### PR TITLE
Close #1 Custom pull refresh indicator

### DIFF
--- a/lib/views/notes/notes_content.dart
+++ b/lib/views/notes/notes_content.dart
@@ -17,10 +17,11 @@ class _NotesContent extends StatelessWidget {
       return _buildEmptyState(context);
     }
 
-    return RefreshIndicator(
+    return NmRefreshIndicator(
       onRefresh: () => viewModel.refreshNotes(),
       child: CustomScrollView(
         controller: viewModel.scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
         slivers: [_buildAppBar(context), _buildNotesList(context)],
       ),
     );

--- a/lib/views/notes/notes_view.dart
+++ b/lib/views/notes/notes_view.dart
@@ -4,6 +4,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:noteminds/core/base/view_model_provider.dart';
 import 'package:noteminds/views/notes/widgets/note_card.dart';
+import 'package:noteminds/widgets/nm_refresh_indicator.dart';
 
 import 'notes_view_model.dart';
 

--- a/lib/widgets/nm_refresh_indicator.dart
+++ b/lib/widgets/nm_refresh_indicator.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class NmRefreshIndicator extends StatelessWidget {
+  const NmRefreshIndicator({
+    super.key,
+    required this.child,
+    required this.onRefresh,
+    this.backgroundColor,
+    this.color,
+    this.strokeWidth = 2,
+    this.elevation = 0,
+  });
+
+  final Widget child;
+  final Future<void> Function() onRefresh;
+  final Color? backgroundColor;
+  final Color? color;
+  final double strokeWidth;
+  final double elevation;
+
+  @override
+  Widget build(BuildContext context) => RefreshIndicator.adaptive(
+    onRefresh: () async {
+      HapticFeedback.heavyImpact();
+      await onRefresh();
+    },
+    backgroundColor: backgroundColor,
+    color: color,
+    strokeWidth: strokeWidth,
+    elevation: elevation,
+    child: child,
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce custom adaptive refresh indicator with haptic feedback and use it in Notes view with always-scrollable list.
> 
> - **UI**:
>   - **Custom Refresh**: Add `NmRefreshIndicator` in `lib/widgets/nm_refresh_indicator.dart` that wraps `RefreshIndicator.adaptive`, triggers `HapticFeedback.heavyImpact`, and exposes `backgroundColor`, `color`, `strokeWidth`, and `elevation`.
>   - **Integration**:
>     - Replace `RefreshIndicator` with `NmRefreshIndicator` in `lib/views/notes/notes_content.dart`.
>     - Add `AlwaysScrollableScrollPhysics` to `CustomScrollView`.
>     - Import new widget in `lib/views/notes/notes_view.dart`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15556c54d7f952d0a598ff6fd69046e5f6e93214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->