### PR TITLE
Close #51 Tok-K relevant documents

### DIFF
--- a/docs/DOCUMENT_RESOLVER_SERVICE.md
+++ b/docs/DOCUMENT_RESOLVER_SERVICE.md
@@ -1,0 +1,389 @@
+# Document Resolver Service (RAG Step 3)
+
+> Resolve raw embedding search results into fully-hydrated note documents
+> with metadata, ready for prompt augmentation.
+
+This document describes the **Top-K Relevant Documents** layer of Trovara's
+RAG pipeline — the component that bridges vector search (Step 2) and prompt
+building (Step 4).
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Architecture](#2-architecture)
+3. [Files & Classes](#3-files--classes)
+4. [RetrievedDocument Model](#4-retrieveddocument-model)
+5. [DocumentResolverService](#5-documentresolverservice)
+6. [Dependency Injection](#6-dependency-injection)
+7. [Usage Examples](#7-usage-examples)
+8. [Testing](#8-testing)
+9. [Future Improvements](#9-future-improvements)
+
+---
+
+## 1. Overview
+
+After `VectorSearchService` (Step 2) returns a flat list of scored embedding
+chunks, we need to:
+
+1. **Group** chunks that belong to the same note
+2. **Hydrate** each group with the full `Note` entity (title, tags, folder, etc.)
+3. **Filter** out deleted or missing notes
+4. **Rank** notes by their best chunk's similarity score
+5. **Limit** results to a top-N set for the prompt context
+
+`DocumentResolverService` performs all of the above and produces a list of
+`RetrievedDocument` objects that the prompt builder (Step 4) can consume
+directly.
+
+---
+
+## 2. Architecture
+
+### Data flow
+
+```
+VectorSearchService.search()
+    │
+    ▼
+List<ScoredEmbedding>           ← flat list of (chunk, score) pairs
+    │
+    ▼
+DocumentResolverService.resolve()
+    │
+    ├─ Group by noteId
+    ├─ Fetch full Note via NoteService.getNote()
+    ├─ Skip deleted / missing notes
+    ├─ Sort chunks within each note by chunkIndex
+    ├─ Rank notes by max similarity score
+    ├─ Limit to top-N (default 5)
+    └─ Optional: trim by total text length
+    │
+    ▼
+List<RetrievedDocument>         ← hydrated, ranked, ready for prompt
+```
+
+### Where it fits in the pipeline
+
+```
+Step 1 (Embed)  →  Step 2 (Search)  →  Step 3 (Resolve)  →  Step 4 (Prompt)
+EmbeddingService   VectorSearchService  DocumentResolverService  RagService
+```
+
+---
+
+## 3. Files & Classes
+
+### New files (Step 3)
+
+| File                                                     | Purpose                             |
+| -------------------------------------------------------- | ----------------------------------- |
+| `lib/models/retrieved_document.dart`                     | `RetrievedDocument` data class      |
+| `lib/core/services/document_resolver_service.dart`       | Resolution, grouping, ranking logic |
+| `test/core/services/document_resolver_service_test.dart` | 15 unit tests                       |
+
+### Modified files
+
+| File                               | Change                                       |
+| ---------------------------------- | -------------------------------------------- |
+| `lib/core/di/service_locator.dart` | Added `DocumentResolverService` registration |
+
+### Class diagram
+
+```
+┌────────────────────────────┐
+│    RetrievedDocument       │
+├────────────────────────────┤
+│ + note: Note               │
+│ + relevantChunks: List<SE> │
+│ + maxScore: double         │
+├────────────────────────────┤
+│ + combinedText: String     │  ← chunks joined by \n\n
+│ + avgScore: double         │
+│ + matchedChunkCount: int   │
+│ + combinedTextLength: int  │
+└────────────────────────────┘
+
+┌─────────────────────────────────┐
+│  DocumentResolverService        │
+├─────────────────────────────────┤
+│ + resolve()                     │  → List<RetrievedDocument>
+│ + resolveToTitles()             │  → List<String>
+│ + resolveToContextMaps()        │  → List<Map<String, String>>
+├─────────────────────────────────┤
+│ - _groupByNoteId()              │
+│ - _trimByTextLength()           │
+└─────────────────────────────────┘
+
+SE = ScoredEmbedding (from vector_search_service.dart)
+```
+
+---
+
+## 4. RetrievedDocument Model
+
+**File:** `lib/models/retrieved_document.dart`
+
+A fully-resolved note paired with the relevant embedding chunks that
+matched a user query.
+
+### Fields
+
+| Field            | Type                    | Description                                              |
+| ---------------- | ----------------------- | -------------------------------------------------------- |
+| `note`           | `Note`                  | Full note entity with title, tags, folder, timestamps    |
+| `relevantChunks` | `List<ScoredEmbedding>` | Matched chunks sorted by `chunkIndex` (reading order)    |
+| `maxScore`       | `double`                | Highest similarity score among chunks — used for ranking |
+
+### Computed properties
+
+| Property             | Type     | Description                               |
+| -------------------- | -------- | ----------------------------------------- |
+| `combinedText`       | `String` | All chunk texts joined with `\n\n`        |
+| `avgScore`           | `double` | Mean similarity across all matched chunks |
+| `matchedChunkCount`  | `int`    | Number of chunks that matched             |
+| `combinedTextLength` | `int`    | Total character count of combined text    |
+
+### Why max score for ranking?
+
+When a note has multiple chunks, some may be highly relevant and others less
+so. Using the **max** score ensures a note with even one highly relevant
+chunk is ranked appropriately, rather than being penalised by averaging in
+lower-scoring chunks.
+
+---
+
+## 5. DocumentResolverService
+
+**File:** `lib/core/services/document_resolver_service.dart`
+
+### Public API
+
+#### `resolve(scoredChunks, {topN, maxTextLength})`
+
+The main method. Takes raw search results and returns hydrated documents.
+
+```dart
+final documents = resolver.resolve(
+  scoredChunks,
+  topN: 5,            // max documents (default: 5)
+  maxTextLength: 20000, // optional char budget
+);
+```
+
+**Parameters:**
+
+| Parameter       | Type                    | Default | Description                                       |
+| --------------- | ----------------------- | ------- | ------------------------------------------------- |
+| `scoredChunks`  | `List<ScoredEmbedding>` | —       | Raw search results from Step 2                    |
+| `topN`          | `int`                   | 5       | Maximum number of documents to return             |
+| `maxTextLength` | `int?`                  | null    | Optional character budget for total combined text |
+
+**Filtering rules:**
+
+- Notes not found in `NoteService` are skipped (embedding orphan)
+- Notes with `isDeleted == true` are skipped (trash)
+- At least one document is always returned when `maxTextLength` is used,
+  even if the single document exceeds the budget
+
+#### `resolveToTitles(scoredChunks, {topN})`
+
+Convenience method that returns just the note titles in ranked order.
+Useful for source attribution in chat responses.
+
+```dart
+final titles = resolver.resolveToTitles(scoredChunks);
+// ['Morning Reflection', 'Weekly Review']
+```
+
+#### `resolveToContextMaps(scoredChunks, {topN})`
+
+Returns a list of metadata maps ready for prompt construction. Each map
+contains:
+
+```dart
+{
+  'title': 'Morning Reflection',
+  'date': '2026-02-20',
+  'folder': 'Journal',
+  'tags': 'mood: happy, grateful | activity: meditation | time: morning',
+  'text': 'The combined chunk text...',
+}
+```
+
+### Constants
+
+| Constant               | Value  | Description                           |
+| ---------------------- | ------ | ------------------------------------- |
+| `defaultTopN`          | 5      | Default number of documents to return |
+| `maxCombinedTextChars` | 20,000 | Safety cap for total context text     |
+
+---
+
+## 6. Dependency Injection
+
+`DocumentResolverService` is registered in `ServiceLocator` with lazy
+initialization. It depends on `NoteService`.
+
+```
+ServiceLocator
+    │
+    ├── noteService ──────────── NoteService
+    │       │
+    │       └── used by ──────── DocumentResolverService
+    │
+    └── documentResolverService ─ DocumentResolverService
+```
+
+**Access:**
+
+```dart
+final resolver = ServiceLocator().documentResolverService;
+```
+
+No explicit initialization is required — the service is stateless and only
+calls `NoteService.getNote()` and `NoteService.getFolder()` at resolve time.
+
+---
+
+## 7. Usage Examples
+
+### Full RAG retrieval (Steps 1 → 2 → 3)
+
+```dart
+final sl = ServiceLocator();
+
+// Step 1: Embed the user's question
+final queryVector = await sl.embeddingService.embedQuery(
+  'What did I write about meditation?',
+);
+if (queryVector == null) return;
+
+// Step 2: Vector search
+final scoredChunks = sl.vectorSearchService.search(
+  queryVector,
+  topK: 10,
+  minScore: 0.3,
+);
+
+// Step 3: Resolve to documents
+final documents = sl.documentResolverService.resolve(
+  scoredChunks,
+  topN: 5,
+);
+
+for (final doc in documents) {
+  print('${doc.note.title} (${doc.maxScore.toStringAsFixed(2)})');
+  print('  Chunks: ${doc.matchedChunkCount}');
+  print('  Text: ${doc.combinedText.substring(0, 80)}...');
+}
+```
+
+### Source attribution for chat
+
+```dart
+final titles = sl.documentResolverService.resolveToTitles(
+  scoredChunks,
+  topN: 3,
+);
+// → ['Morning Reflection', 'Weekly Review']
+// Display as: "📎 Sources: Morning Reflection, Weekly Review"
+```
+
+### Prompt-ready context
+
+```dart
+final contextMaps = sl.documentResolverService.resolveToContextMaps(
+  scoredChunks,
+  topN: 5,
+);
+for (final ctx in contextMaps) {
+  prompt.writeln('Title: ${ctx['title']}');
+  prompt.writeln('Date: ${ctx['date']}');
+  prompt.writeln('Folder: ${ctx['folder']}');
+  prompt.writeln('Tags: ${ctx['tags']}');
+  prompt.writeln('Content:\n${ctx['text']}');
+}
+```
+
+---
+
+## 8. Testing
+
+**File:** `test/core/services/document_resolver_service_test.dart`
+
+Tests use stub implementations of `INoteRepository` and
+`IFolderRepository`, injected into a real `NoteService`. No ObjectBox or
+network dependencies.
+
+### Test coverage (15 tests)
+
+| Group                | Test                           | Validates                 |
+| -------------------- | ------------------------------ | ------------------------- |
+| resolve              | empty input → empty list       | Empty state               |
+| resolve              | single chunk → single document | Basic resolution          |
+| resolve              | multiple chunks → grouped      | Chunk grouping by noteId  |
+| resolve              | ranked by max score descending | Ranking correctness       |
+| resolve              | deleted notes filtered out     | Trash handling            |
+| resolve              | missing notes filtered out     | Orphan embedding handling |
+| resolve              | respects topN limit            | Result limiting           |
+| resolve              | trims by maxTextLength         | Token budget management   |
+| resolve              | always includes ≥ 1 doc        | Edge case for tiny budget |
+| resolve              | max score with varying chunks  | Multi-score ranking       |
+| RetrievedDocument    | combinedText joins with \\n\\n | Text assembly             |
+| RetrievedDocument    | avgScore computed correctly    | Average calculation       |
+| resolveToTitles      | titles in ranked order         | Convenience method        |
+| resolveToContextMaps | metadata included              | Prompt context            |
+| resolveToContextMaps | default folder fallback        | Missing folder            |
+
+### Running tests
+
+```bash
+flutter test test/core/services/document_resolver_service_test.dart
+```
+
+---
+
+## 9. Future Improvements
+
+**Short-term:**
+
+- Chunk de-overlapping — when two chunks overlap (200 chars), merge the
+  overlap region in `combinedText` to avoid duplicate sentences in the prompt.
+- Per-note chunk limit — cap the number of chunks per note (e.g. max 3) to
+  prevent a single long note from dominating the context.
+
+**Medium-term:**
+
+- Metadata scoring boost — optionally boost the score of notes whose tags
+  match query keywords (e.g. query contains "happy" and note has mood tag
+  "happy").
+- Recency weighting — apply a small boost for more recent notes so the LLM
+  prioritises fresh content.
+
+**Long-term:**
+
+- Cross-note deduplication — detect near-duplicate content across different
+  notes and consolidate before passing to the prompt.
+- Streaming resolution — resolve documents lazily as chunks arrive from a
+  streaming search, useful if the vector index grows very large.
+
+---
+
+## Relationship to Other RAG Steps
+
+| Step  | Component                     | Status      | Connects to Step 3 via                                   |
+| ----- | ----------------------------- | ----------- | -------------------------------------------------------- |
+| 1     | Embedding Model               | ✅ Done     | Generates embeddings stored in ObjectBox                 |
+| 2     | Vector Storage & Search       | ✅ Done     | Returns `List<ScoredEmbedding>` — input to resolver      |
+| **3** | **Top-K Document Resolution** | **✅ Done** | **Outputs `List<RetrievedDocument>` for prompt builder** |
+| 4     | Prompt Augmentation           | Planned     | Consumes `RetrievedDocument` to build LLM prompt         |
+| 5     | LLM Generator                 | Planned     | Sends augmented prompt to Gemini                         |
+| 6     | Chat UI                       | Planned     | Displays answer with source attribution                  |
+
+---
+
+_Document created: February 27, 2026_
+_Relates to: [RAG_IMPLEMENTATION.md](RAG_IMPLEMENTATION.md) — Step 3_

--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -9,6 +9,7 @@ import 'package:trovara/core/repository/interfaces/embedding_repository.dart';
 import 'package:trovara/core/repository/interfaces/folder_repository.dart';
 import 'package:trovara/core/repository/interfaces/note_repository.dart';
 import 'package:trovara/core/services/custom_tag_service.dart';
+import 'package:trovara/core/services/document_resolver_service.dart';
 import 'package:trovara/core/services/embedding_service.dart';
 import 'package:trovara/core/services/google_drive_service.dart';
 import 'package:trovara/core/services/google_drive_sync_service.dart';
@@ -31,6 +32,7 @@ class ServiceLocator {
   CustomTagService? _customTagService;
   EmbeddingService? _embeddingService;
   VectorSearchService? _vectorSearchService;
+  DocumentResolverService? _documentResolverService;
   GoogleDriveService? _googleDriveService;
   GoogleDriveSyncService? _googleDriveSyncService;
 
@@ -71,6 +73,12 @@ class ServiceLocator {
   VectorSearchService get vectorSearchService {
     _vectorSearchService ??= VectorSearchService(repository: embeddingRepository);
     return _vectorSearchService!;
+  }
+
+  /// Get the document resolver service instance
+  DocumentResolverService get documentResolverService {
+    _documentResolverService ??= DocumentResolverService(noteService: noteService);
+    return _documentResolverService!;
   }
 
   /// Get the note service instance
@@ -126,5 +134,6 @@ class ServiceLocator {
     _embeddingRepository = null;
     _embeddingService = null;
     _vectorSearchService = null;
+    _documentResolverService = null;
   }
 }

--- a/lib/core/services/document_resolver_service.dart
+++ b/lib/core/services/document_resolver_service.dart
@@ -1,0 +1,178 @@
+import 'dart:math';
+
+import 'package:logger/logger.dart';
+import 'package:trovara/core/services/note_service.dart';
+import 'package:trovara/core/services/vector_search_service.dart';
+import 'package:trovara/models/retrieved_document.dart';
+
+/// Resolves raw [ScoredEmbedding] chunks from vector search into
+/// fully-hydrated [RetrievedDocument] objects.
+///
+/// This is **Step 3** of the RAG pipeline:
+///
+/// ```
+/// ScoredEmbedding list (Step 2)
+///     │
+///     ▼
+/// Group by noteId  ──► Fetch full Note  ──► Rank  ──► Top-N
+///     │
+///     ▼
+/// List<RetrievedDocument> (→ Step 4 prompt builder)
+/// ```
+///
+/// Responsibilities:
+/// - Group scored chunks by their parent note
+/// - Fetch the full [Note] entity for each group
+/// - Filter out deleted or inaccessible notes
+/// - Sort chunks within each note by reading order
+/// - Rank notes by highest similarity score
+/// - Limit results to a configurable top-N
+class DocumentResolverService {
+  final NoteService _noteService;
+  final Logger _logger = Logger();
+
+  /// Default maximum number of documents to return.
+  static const int defaultTopN = 5;
+
+  /// Maximum combined text length (chars) to include in the prompt context.
+  /// Prevents excessive token usage even with Gemini's large context window.
+  static const int maxCombinedTextChars = 20000;
+
+  DocumentResolverService({required NoteService noteService}) : _noteService = noteService;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  //  Public API
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /// Resolve scored embedding chunks into ranked [RetrievedDocument]s.
+  ///
+  /// 1. Groups [scoredChunks] by `noteId`
+  /// 2. Fetches the full [Note] for each group
+  /// 3. Filters out deleted or missing notes
+  /// 4. Sorts chunks within each note by `chunkIndex` (reading order)
+  /// 5. Ranks notes by max similarity score (descending)
+  /// 6. Returns the top-[topN] documents
+  ///
+  /// If [maxTextLength] is provided, the result list is further trimmed so
+  /// the total combined text does not exceed that limit.
+  List<RetrievedDocument> resolve(List<ScoredEmbedding> scoredChunks, {int topN = defaultTopN, int? maxTextLength}) {
+    if (scoredChunks.isEmpty) return [];
+
+    // Step 1: Group chunks by noteId
+    final noteGroups = _groupByNoteId(scoredChunks);
+
+    // Step 2 & 3: Fetch notes and build RetrievedDocuments
+    final documents = <RetrievedDocument>[];
+
+    for (final entry in noteGroups.entries) {
+      final note = _noteService.getNote(entry.key);
+
+      // Skip missing or deleted notes
+      if (note == null) {
+        _logger.d('Skipping missing note ${entry.key}');
+        continue;
+      }
+      if (note.isDeleted) {
+        _logger.d('Skipping deleted note ${entry.key}');
+        continue;
+      }
+
+      // Step 4: Sort chunks by chunkIndex for reading order
+      final chunks = entry.value..sort((a, b) => a.embedding.chunkIndex.compareTo(b.embedding.chunkIndex));
+
+      // Compute the max score for ranking
+      final maxScore = chunks.map((c) => c.score).reduce(max);
+
+      documents.add(RetrievedDocument(note: note, relevantChunks: chunks, maxScore: maxScore));
+    }
+
+    // Step 5: Rank by descending max score
+    documents.sort((a, b) => b.maxScore.compareTo(a.maxScore));
+
+    // Step 6: Limit to top-N
+    final topDocuments = documents.take(topN).toList();
+
+    // Optional: trim by total text length
+    if (maxTextLength != null) {
+      return _trimByTextLength(topDocuments, maxTextLength);
+    }
+
+    _logger.d(
+      'Resolved ${scoredChunks.length} chunks → '
+      '${documents.length} notes → '
+      '${topDocuments.length} returned',
+    );
+
+    return topDocuments;
+  }
+
+  /// Convenience method: resolve and return only the note titles.
+  ///
+  /// Useful for source attribution in chat responses.
+  List<String> resolveToTitles(List<ScoredEmbedding> scoredChunks, {int topN = defaultTopN}) {
+    final docs = resolve(scoredChunks, topN: topN);
+    return docs.map((d) => d.note.title).toList();
+  }
+
+  /// Convenience method: resolve and return combined text suitable for
+  /// prompt building.
+  ///
+  /// Each entry is a map with `title`, `text`, `date`, `folder`, and `tags`.
+  List<Map<String, String>> resolveToContextMaps(List<ScoredEmbedding> scoredChunks, {int topN = defaultTopN}) {
+    final docs = resolve(scoredChunks, topN: topN);
+    return docs.map((doc) {
+      final note = doc.note;
+      final folder = _noteService.getFolder(note.folderId);
+
+      // Build tag string
+      final tags = <String>[];
+      if (note.moodTags.isNotEmpty) tags.add('mood: ${note.moodTags.join(", ")}');
+      if (note.activityTags.isNotEmpty) tags.add('activity: ${note.activityTags.join(", ")}');
+      if (note.timeTags.isNotEmpty) tags.add('time: ${note.timeTags.join(", ")}');
+      if (note.personalGrowthTags.isNotEmpty) {
+        tags.add('growth: ${note.personalGrowthTags.join(", ")}');
+      }
+
+      return {
+        'title': note.title,
+        'date': note.createdAt.toIso8601String().split('T')[0],
+        'folder': folder?.name ?? 'Default',
+        'tags': tags.join(' | '),
+        'text': doc.combinedText,
+      };
+    }).toList();
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  //  Private Helpers
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /// Group scored chunks by their parent noteId.
+  Map<int, List<ScoredEmbedding>> _groupByNoteId(List<ScoredEmbedding> chunks) {
+    final groups = <int, List<ScoredEmbedding>>{};
+    for (final chunk in chunks) {
+      groups.putIfAbsent(chunk.embedding.noteId, () => []).add(chunk);
+    }
+    return groups;
+  }
+
+  /// Trim the document list so total combined text stays within [maxLength].
+  ///
+  /// Documents are already sorted by relevance, so we include as many as
+  /// possible within the budget.
+  List<RetrievedDocument> _trimByTextLength(List<RetrievedDocument> docs, int maxLength) {
+    final result = <RetrievedDocument>[];
+    int currentLength = 0;
+
+    for (final doc in docs) {
+      final docLength = doc.combinedTextLength;
+      if (currentLength + docLength > maxLength && result.isNotEmpty) {
+        break;
+      }
+      result.add(doc);
+      currentLength += docLength;
+    }
+
+    return result;
+  }
+}

--- a/lib/models/retrieved_document.dart
+++ b/lib/models/retrieved_document.dart
@@ -1,0 +1,46 @@
+import 'package:trovara/core/services/vector_search_service.dart';
+import 'package:trovara/models/note.dart';
+
+/// A fully-resolved note paired with the relevant embedding chunks that
+/// matched a user query and the highest similarity score among them.
+///
+/// Produced by [DocumentResolverService] after grouping raw
+/// [ScoredEmbedding] results by note and fetching the full [Note] entity.
+class RetrievedDocument {
+  /// The full [Note] entity this document represents.
+  final Note note;
+
+  /// The embedding chunks that matched the query, sorted by ascending
+  /// [NoteEmbedding.chunkIndex] so they can be displayed in reading order.
+  final List<ScoredEmbedding> relevantChunks;
+
+  /// The highest similarity score among all [relevantChunks].
+  /// Used to rank documents against each other.
+  final double maxScore;
+
+  RetrievedDocument({required this.note, required this.relevantChunks, required this.maxScore});
+
+  /// Combined text of all relevant chunks in reading order.
+  ///
+  /// Chunks are separated by double newlines. Useful for building the
+  /// augmented prompt (Step 4) without re-parsing the original note.
+  String get combinedText => relevantChunks.map((c) => c.embedding.chunkText).join('\n\n');
+
+  /// Average similarity score across all matched chunks.
+  double get avgScore {
+    if (relevantChunks.isEmpty) return 0.0;
+    final total = relevantChunks.fold<double>(0.0, (sum, c) => sum + c.score);
+    return total / relevantChunks.length;
+  }
+
+  /// Number of chunks from this note that matched the query.
+  int get matchedChunkCount => relevantChunks.length;
+
+  /// Total character count of the combined relevant text.
+  int get combinedTextLength => combinedText.length;
+
+  @override
+  String toString() =>
+      'RetrievedDocument(noteId: ${note.id}, title: "${note.title}", '
+      'chunks: $matchedChunkCount, maxScore: ${maxScore.toStringAsFixed(4)})';
+}

--- a/test/core/services/document_resolver_service_test.dart
+++ b/test/core/services/document_resolver_service_test.dart
@@ -1,0 +1,366 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trovara/core/repository/interfaces/folder_repository.dart';
+import 'package:trovara/core/repository/interfaces/note_repository.dart';
+import 'package:trovara/core/services/document_resolver_service.dart';
+import 'package:trovara/core/services/note_service.dart';
+import 'package:trovara/core/services/vector_search_service.dart';
+import 'package:trovara/models/folder.dart';
+import 'package:trovara/models/note.dart';
+import 'package:trovara/models/note_embedding.dart';
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Minimal stubs for NoteService dependencies
+// ═══════════════════════════════════════════════════════════════════════════
+
+class StubNoteRepository implements INoteRepository {
+  final Map<int, Note> _notes = {};
+
+  void addNote(Note note) => _notes[note.id] = note;
+
+  @override
+  Note? getNoteById(int id) => _notes[id];
+
+  @override
+  Future<void> initialize() async {}
+
+  // ─── Unused stubs ───
+  @override
+  List<Note> getActiveNotes() => _notes.values.where((n) => !n.isDeleted).toList();
+  @override
+  List<Note> getAllNotes() => _notes.values.toList();
+  @override
+  List<Note> searchNotes(String query) => [];
+  @override
+  List<Note> getNotesByFolder(String folderId) => [];
+  @override
+  List<Note> getFavoriteNotes() => [];
+  @override
+  List<Note> getArchivedNotes() => [];
+  @override
+  List<Note> getNotesByTag(String tag) => [];
+  @override
+  List<String> getAllTags() => [];
+  @override
+  List<Note> getDeletedNotes() => [];
+  @override
+  Future<Note> createNote({String? title, String? contentJson, String? folderId, List<int> customTagIds = const []}) =>
+      throw UnimplementedError();
+  @override
+  Future<Note> createNoteWithTimestamps({
+    String? title,
+    String? contentJson,
+    String? folderId,
+    List<int> customTagIds = const [],
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    bool isFavorite = false,
+    bool isArchived = false,
+    bool isDeleted = false,
+    DateTime? deletedAt,
+    String? driveFileId,
+    List<String>? moodTags,
+    List<String>? activityTags,
+    List<String>? timeTags,
+    List<String>? personalGrowthTags,
+  }) => throw UnimplementedError();
+  @override
+  Future<void> updateNote(Note note) async {}
+  @override
+  Future<void> deleteNote(int id) async {}
+  @override
+  int get totalNotes => _notes.length;
+  @override
+  int get totalWords => 0;
+  @override
+  int get totalCharacters => 0;
+  @override
+  void addListener(Function() listener) {}
+  @override
+  void removeListener(Function() listener) {}
+  @override
+  void dispose() {}
+}
+
+class StubFolderRepository implements IFolderRepository {
+  final Map<String, Folder> _folders = {};
+
+  void addFolder(Folder folder) => _folders[folder.folderId] = folder;
+
+  @override
+  Folder? getFolderById(String folderId) => _folders[folderId];
+
+  @override
+  Future<void> initialize() async {}
+
+  // ─── Unused stubs ───
+  @override
+  List<Folder> getAllFolders() => _folders.values.toList();
+  @override
+  Future<Folder> createFolder({required String name, String? description, String? color}) => throw UnimplementedError();
+  @override
+  Future<Folder> createFolderWithTimestamps({
+    required String folderId,
+    required String name,
+    String? description,
+    String? color,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    bool isDefault = false,
+    int noteCount = 0,
+  }) => throw UnimplementedError();
+  @override
+  Future<void> updateFolder(Folder folder) async {}
+  @override
+  Future<void> deleteFolder(String folderId) async {}
+  @override
+  Folder? getDefaultFolder() => null;
+  @override
+  void addListener(Function() listener) {}
+  @override
+  void removeListener(Function() listener) {}
+  @override
+  void dispose() {}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Test helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+ScoredEmbedding _scored({
+  required int noteId,
+  int chunkIndex = 0,
+  required double score,
+  String chunkText = 'chunk text',
+}) => ScoredEmbedding(
+  embedding: NoteEmbedding(
+    noteId: noteId,
+    chunkIndex: chunkIndex,
+    chunkText: chunkText,
+    embeddingData: NoteEmbedding.serializeEmbedding([0.1, 0.2, 0.3]),
+    modelVersion: 'text-embedding-004',
+    noteUpdatedAt: DateTime.now(),
+  ),
+  score: score,
+);
+
+Note _note({
+  required int id,
+  String title = 'Test Note',
+  bool isDeleted = false,
+  String folderId = 'default',
+  List<String>? moodTags,
+  List<String>? activityTags,
+}) {
+  final note = Note(
+    title: title,
+    contentJson: '[{"insert":"test content\\n"}]',
+    folderId: folderId,
+    isDeleted: isDeleted,
+    moodTags: moodTags,
+    activityTags: activityTags,
+  );
+  note.id = id;
+  return note;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+void main() {
+  group('DocumentResolverService', () {
+    late StubNoteRepository noteRepo;
+    late StubFolderRepository folderRepo;
+    late NoteService noteService;
+    late DocumentResolverService resolver;
+
+    setUp(() {
+      noteRepo = StubNoteRepository();
+      folderRepo = StubFolderRepository();
+      noteService = NoteService(noteRepository: noteRepo, folderRepository: folderRepo);
+      resolver = DocumentResolverService(noteService: noteService);
+    });
+
+    group('resolve', () {
+      test('returns empty list for empty input', () {
+        final result = resolver.resolve([]);
+        expect(result, isEmpty);
+      });
+
+      test('resolves a single chunk to a single document', () {
+        noteRepo.addNote(_note(id: 1, title: 'My Note'));
+
+        final result = resolver.resolve([_scored(noteId: 1, score: 0.85)]);
+
+        expect(result.length, 1);
+        expect(result.first.note.id, 1);
+        expect(result.first.note.title, 'My Note');
+        expect(result.first.maxScore, closeTo(0.85, 0.001));
+        expect(result.first.matchedChunkCount, 1);
+      });
+
+      test('groups multiple chunks from the same note', () {
+        noteRepo.addNote(_note(id: 1));
+
+        final result = resolver.resolve([
+          _scored(noteId: 1, chunkIndex: 0, score: 0.9, chunkText: 'chunk 0'),
+          _scored(noteId: 1, chunkIndex: 1, score: 0.7, chunkText: 'chunk 1'),
+        ]);
+
+        expect(result.length, 1);
+        expect(result.first.matchedChunkCount, 2);
+        expect(result.first.maxScore, closeTo(0.9, 0.001));
+        // Chunks in reading order
+        expect(result.first.relevantChunks[0].embedding.chunkIndex, 0);
+        expect(result.first.relevantChunks[1].embedding.chunkIndex, 1);
+      });
+
+      test('ranks documents by max score descending', () {
+        noteRepo.addNote(_note(id: 1, title: 'Low'));
+        noteRepo.addNote(_note(id: 2, title: 'High'));
+        noteRepo.addNote(_note(id: 3, title: 'Mid'));
+
+        final result = resolver.resolve([
+          _scored(noteId: 1, score: 0.3),
+          _scored(noteId: 2, score: 0.95),
+          _scored(noteId: 3, score: 0.6),
+        ]);
+
+        expect(result.length, 3);
+        expect(result[0].note.id, 2);
+        expect(result[1].note.id, 3);
+        expect(result[2].note.id, 1);
+      });
+
+      test('filters out deleted notes', () {
+        noteRepo.addNote(_note(id: 1, isDeleted: true));
+        noteRepo.addNote(_note(id: 2));
+
+        final result = resolver.resolve([_scored(noteId: 1, score: 0.9), _scored(noteId: 2, score: 0.8)]);
+
+        expect(result.length, 1);
+        expect(result.first.note.id, 2);
+      });
+
+      test('filters out missing notes', () {
+        noteRepo.addNote(_note(id: 1));
+
+        final result = resolver.resolve([_scored(noteId: 1, score: 0.8), _scored(noteId: 99, score: 0.95)]);
+
+        expect(result.length, 1);
+        expect(result.first.note.id, 1);
+      });
+
+      test('respects topN limit', () {
+        for (int i = 1; i <= 10; i++) {
+          noteRepo.addNote(_note(id: i, title: 'Note $i'));
+        }
+
+        final chunks = List.generate(10, (i) => _scored(noteId: i + 1, score: 1.0 - i * 0.05));
+
+        final result = resolver.resolve(chunks, topN: 3);
+
+        expect(result.length, 3);
+        expect(result[0].note.id, 1);
+        expect(result[1].note.id, 2);
+        expect(result[2].note.id, 3);
+      });
+
+      test('trims by maxTextLength', () {
+        noteRepo.addNote(_note(id: 1));
+        noteRepo.addNote(_note(id: 2));
+
+        final longText = 'x' * 5000;
+        final result = resolver.resolve([
+          _scored(noteId: 1, score: 0.9, chunkText: longText),
+          _scored(noteId: 2, score: 0.8, chunkText: longText),
+        ], maxTextLength: 6000);
+
+        expect(result.length, 1);
+        expect(result.first.note.id, 1);
+      });
+
+      test('always includes at least one document even if it exceeds maxTextLength', () {
+        noteRepo.addNote(_note(id: 1));
+
+        final longText = 'x' * 10000;
+        final result = resolver.resolve([_scored(noteId: 1, score: 0.9, chunkText: longText)], maxTextLength: 100);
+
+        expect(result.length, 1);
+      });
+
+      test('uses max score when note has chunks with varying scores', () {
+        noteRepo.addNote(_note(id: 1));
+
+        final result = resolver.resolve([
+          _scored(noteId: 1, chunkIndex: 0, score: 0.4),
+          _scored(noteId: 1, chunkIndex: 1, score: 0.9),
+          _scored(noteId: 1, chunkIndex: 2, score: 0.6),
+        ]);
+
+        expect(result.first.maxScore, closeTo(0.9, 0.001));
+      });
+    });
+
+    group('RetrievedDocument', () {
+      test('combinedText joins chunks with double newline', () {
+        noteRepo.addNote(_note(id: 1));
+
+        final result = resolver.resolve([
+          _scored(noteId: 1, chunkIndex: 0, score: 0.9, chunkText: 'Hello'),
+          _scored(noteId: 1, chunkIndex: 1, score: 0.8, chunkText: 'World'),
+        ]);
+
+        expect(result.first.combinedText, 'Hello\n\nWorld');
+      });
+
+      test('avgScore is computed correctly', () {
+        noteRepo.addNote(_note(id: 1));
+
+        final result = resolver.resolve([
+          _scored(noteId: 1, chunkIndex: 0, score: 0.8),
+          _scored(noteId: 1, chunkIndex: 1, score: 0.6),
+        ]);
+
+        expect(result.first.avgScore, closeTo(0.7, 0.001));
+      });
+    });
+
+    group('resolveToTitles', () {
+      test('returns note titles in ranked order', () {
+        noteRepo.addNote(_note(id: 1, title: 'Alpha'));
+        noteRepo.addNote(_note(id: 2, title: 'Beta'));
+
+        final titles = resolver.resolveToTitles([_scored(noteId: 1, score: 0.5), _scored(noteId: 2, score: 0.9)]);
+
+        expect(titles, ['Beta', 'Alpha']);
+      });
+    });
+
+    group('resolveToContextMaps', () {
+      test('returns context maps with metadata', () {
+        noteRepo.addNote(
+          _note(id: 1, title: 'Morning Walk', folderId: 'journal', moodTags: ['happy'], activityTags: ['walking']),
+        );
+        folderRepo.addFolder(Folder(folderId: 'journal', name: 'Journal'));
+
+        final maps = resolver.resolveToContextMaps([_scored(noteId: 1, score: 0.9, chunkText: 'Went for a walk')]);
+
+        expect(maps.length, 1);
+        expect(maps.first['title'], 'Morning Walk');
+        expect(maps.first['folder'], 'Journal');
+        expect(maps.first['tags'], contains('mood: happy'));
+        expect(maps.first['tags'], contains('activity: walking'));
+        expect(maps.first['text'], 'Went for a walk');
+      });
+
+      test('defaults folder name to Default when folder not found', () {
+        noteRepo.addNote(_note(id: 1, folderId: 'missing'));
+
+        final maps = resolver.resolveToContextMaps([_scored(noteId: 1, score: 0.9)]);
+
+        expect(maps.first['folder'], 'Default');
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Document Resolver Service (RAG Step 3)

> Resolve raw embedding search results into fully-hydrated note documents
> with metadata, ready for prompt augmentation.

This document describes the **Top-K Relevant Documents** layer of Trovara's
RAG pipeline — the component that bridges vector search (Step 2) and prompt
building (Step 4).

---

## Table of Contents

1. [Overview](#1-overview)
2. [Architecture](#2-architecture)
3. [Files & Classes](#3-files--classes)
4. [RetrievedDocument Model](#4-retrieveddocument-model)
5. [DocumentResolverService](#5-documentresolverservice)
6. [Dependency Injection](#6-dependency-injection)
7. [Usage Examples](#7-usage-examples)
8. [Testing](#8-testing)
9. [Future Improvements](#9-future-improvements)

---

## 1. Overview

After `VectorSearchService` (Step 2) returns a flat list of scored embedding
chunks, we need to:

1. **Group** chunks that belong to the same note
2. **Hydrate** each group with the full `Note` entity (title, tags, folder, etc.)
3. **Filter** out deleted or missing notes
4. **Rank** notes by their best chunk's similarity score
5. **Limit** results to a top-N set for the prompt context

`DocumentResolverService` performs all of the above and produces a list of
`RetrievedDocument` objects that the prompt builder (Step 4) can consume
directly.

---

## 2. Architecture

### Data flow

```
VectorSearchService.search()
    │
    ▼
List<ScoredEmbedding>           ← flat list of (chunk, score) pairs
    │
    ▼
DocumentResolverService.resolve()
    │
    ├─ Group by noteId
    ├─ Fetch full Note via NoteService.getNote()
    ├─ Skip deleted / missing notes
    ├─ Sort chunks within each note by chunkIndex
    ├─ Rank notes by max similarity score
    ├─ Limit to top-N (default 5)
    └─ Optional: trim by total text length
    │
    ▼
List<RetrievedDocument>         ← hydrated, ranked, ready for prompt
```

### Where it fits in the pipeline

```
Step 1 (Embed)  →  Step 2 (Search)  →  Step 3 (Resolve)  →  Step 4 (Prompt)
EmbeddingService   VectorSearchService  DocumentResolverService  RagService
```

---

## 3. Files & Classes

### New files (Step 3)

| File                                                     | Purpose                             |
| -------------------------------------------------------- | ----------------------------------- |
| `lib/models/retrieved_document.dart`                     | `RetrievedDocument` data class      |
| `lib/core/services/document_resolver_service.dart`       | Resolution, grouping, ranking logic |
| `test/core/services/document_resolver_service_test.dart` | 15 unit tests                       |

### Modified files

| File                               | Change                                       |
| ---------------------------------- | -------------------------------------------- |
| `lib/core/di/service_locator.dart` | Added `DocumentResolverService` registration |

### Class diagram

```
┌────────────────────────────┐
│    RetrievedDocument       │
├────────────────────────────┤
│ + note: Note               │
│ + relevantChunks: List<SE> │
│ + maxScore: double         │
├────────────────────────────┤
│ + combinedText: String     │  ← chunks joined by \n\n
│ + avgScore: double         │
│ + matchedChunkCount: int   │
│ + combinedTextLength: int  │
└────────────────────────────┘

┌─────────────────────────────────┐
│  DocumentResolverService        │
├─────────────────────────────────┤
│ + resolve()                     │  → List<RetrievedDocument>
│ + resolveToTitles()             │  → List<String>
│ + resolveToContextMaps()        │  → List<Map<String, String>>
├─────────────────────────────────┤
│ - _groupByNoteId()              │
│ - _trimByTextLength()           │
└─────────────────────────────────┘

SE = ScoredEmbedding (from vector_search_service.dart)
```

---

## 4. RetrievedDocument Model

**File:** `lib/models/retrieved_document.dart`

A fully-resolved note paired with the relevant embedding chunks that
matched a user query.

### Fields

| Field            | Type                    | Description                                              |
| ---------------- | ----------------------- | -------------------------------------------------------- |
| `note`           | `Note`                  | Full note entity with title, tags, folder, timestamps    |
| `relevantChunks` | `List<ScoredEmbedding>` | Matched chunks sorted by `chunkIndex` (reading order)    |
| `maxScore`       | `double`                | Highest similarity score among chunks — used for ranking |

### Computed properties

| Property             | Type     | Description                               |
| -------------------- | -------- | ----------------------------------------- |
| `combinedText`       | `String` | All chunk texts joined with `\n\n`        |
| `avgScore`           | `double` | Mean similarity across all matched chunks |
| `matchedChunkCount`  | `int`    | Number of chunks that matched             |
| `combinedTextLength` | `int`    | Total character count of combined text    |

### Why max score for ranking?

When a note has multiple chunks, some may be highly relevant and others less
so. Using the **max** score ensures a note with even one highly relevant
chunk is ranked appropriately, rather than being penalised by averaging in
lower-scoring chunks.

---

## 5. DocumentResolverService

**File:** `lib/core/services/document_resolver_service.dart`

### Public API

#### `resolve(scoredChunks, {topN, maxTextLength})`

The main method. Takes raw search results and returns hydrated documents.

```dart
final documents = resolver.resolve(
  scoredChunks,
  topN: 5,            // max documents (default: 5)
  maxTextLength: 20000, // optional char budget
);
```

**Parameters:**

| Parameter       | Type                    | Default | Description                                       |
| --------------- | ----------------------- | ------- | ------------------------------------------------- |
| `scoredChunks`  | `List<ScoredEmbedding>` | —       | Raw search results from Step 2                    |
| `topN`          | `int`                   | 5       | Maximum number of documents to return             |
| `maxTextLength` | `int?`                  | null    | Optional character budget for total combined text |

**Filtering rules:**

- Notes not found in `NoteService` are skipped (embedding orphan)
- Notes with `isDeleted == true` are skipped (trash)
- At least one document is always returned when `maxTextLength` is used,
  even if the single document exceeds the budget

#### `resolveToTitles(scoredChunks, {topN})`

Convenience method that returns just the note titles in ranked order.
Useful for source attribution in chat responses.

```dart
final titles = resolver.resolveToTitles(scoredChunks);
// ['Morning Reflection', 'Weekly Review']
```

#### `resolveToContextMaps(scoredChunks, {topN})`

Returns a list of metadata maps ready for prompt construction. Each map
contains:

```dart
{
  'title': 'Morning Reflection',
  'date': '2026-02-20',
  'folder': 'Journal',
  'tags': 'mood: happy, grateful | activity: meditation | time: morning',
  'text': 'The combined chunk text...',
}
```

### Constants

| Constant               | Value  | Description                           |
| ---------------------- | ------ | ------------------------------------- |
| `defaultTopN`          | 5      | Default number of documents to return |
| `maxCombinedTextChars` | 20,000 | Safety cap for total context text     |

---

## 6. Dependency Injection

`DocumentResolverService` is registered in `ServiceLocator` with lazy
initialization. It depends on `NoteService`.

```
ServiceLocator
    │
    ├── noteService ──────────── NoteService
    │       │
    │       └── used by ──────── DocumentResolverService
    │
    └── documentResolverService ─ DocumentResolverService
```

**Access:**

```dart
final resolver = ServiceLocator().documentResolverService;
```

No explicit initialization is required — the service is stateless and only
calls `NoteService.getNote()` and `NoteService.getFolder()` at resolve time.

---

## 7. Usage Examples

### Full RAG retrieval (Steps 1 → 2 → 3)

```dart
final sl = ServiceLocator();

// Step 1: Embed the user's question
final queryVector = await sl.embeddingService.embedQuery(
  'What did I write about meditation?',
);
if (queryVector == null) return;

// Step 2: Vector search
final scoredChunks = sl.vectorSearchService.search(
  queryVector,
  topK: 10,
  minScore: 0.3,
);

// Step 3: Resolve to documents
final documents = sl.documentResolverService.resolve(
  scoredChunks,
  topN: 5,
);

for (final doc in documents) {
  print('${doc.note.title} (${doc.maxScore.toStringAsFixed(2)})');
  print('  Chunks: ${doc.matchedChunkCount}');
  print('  Text: ${doc.combinedText.substring(0, 80)}...');
}
```

### Source attribution for chat

```dart
final titles = sl.documentResolverService.resolveToTitles(
  scoredChunks,
  topN: 3,
);
// → ['Morning Reflection', 'Weekly Review']
// Display as: "📎 Sources: Morning Reflection, Weekly Review"
```

### Prompt-ready context

```dart
final contextMaps = sl.documentResolverService.resolveToContextMaps(
  scoredChunks,
  topN: 5,
);
for (final ctx in contextMaps) {
  prompt.writeln('Title: ${ctx['title']}');
  prompt.writeln('Date: ${ctx['date']}');
  prompt.writeln('Folder: ${ctx['folder']}');
  prompt.writeln('Tags: ${ctx['tags']}');
  prompt.writeln('Content:\n${ctx['text']}');
}
```

---

## 8. Testing

**File:** `test/core/services/document_resolver_service_test.dart`

Tests use stub implementations of `INoteRepository` and
`IFolderRepository`, injected into a real `NoteService`. No ObjectBox or
network dependencies.

### Test coverage (15 tests)

| Group                | Test                           | Validates                 |
| -------------------- | ------------------------------ | ------------------------- |
| resolve              | empty input → empty list       | Empty state               |
| resolve              | single chunk → single document | Basic resolution          |
| resolve              | multiple chunks → grouped      | Chunk grouping by noteId  |
| resolve              | ranked by max score descending | Ranking correctness       |
| resolve              | deleted notes filtered out     | Trash handling            |
| resolve              | missing notes filtered out     | Orphan embedding handling |
| resolve              | respects topN limit            | Result limiting           |
| resolve              | trims by maxTextLength         | Token budget management   |
| resolve              | always includes ≥ 1 doc        | Edge case for tiny budget |
| resolve              | max score with varying chunks  | Multi-score ranking       |
| RetrievedDocument    | combinedText joins with \\n\\n | Text assembly             |
| RetrievedDocument    | avgScore computed correctly    | Average calculation       |
| resolveToTitles      | titles in ranked order         | Convenience method        |
| resolveToContextMaps | metadata included              | Prompt context            |
| resolveToContextMaps | default folder fallback        | Missing folder            |

### Running tests

```bash
flutter test test/core/services/document_resolver_service_test.dart
```

---

## 9. Future Improvements

**Short-term:**

- Chunk de-overlapping — when two chunks overlap (200 chars), merge the
  overlap region in `combinedText` to avoid duplicate sentences in the prompt.
- Per-note chunk limit — cap the number of chunks per note (e.g. max 3) to
  prevent a single long note from dominating the context.

**Medium-term:**

- Metadata scoring boost — optionally boost the score of notes whose tags
  match query keywords (e.g. query contains "happy" and note has mood tag
  "happy").
- Recency weighting — apply a small boost for more recent notes so the LLM
  prioritises fresh content.

**Long-term:**

- Cross-note deduplication — detect near-duplicate content across different
  notes and consolidate before passing to the prompt.
- Streaming resolution — resolve documents lazily as chunks arrive from a
  streaming search, useful if the vector index grows very large.

---

## Relationship to Other RAG Steps

| Step  | Component                     | Status      | Connects to Step 3 via                                   |
| ----- | ----------------------------- | ----------- | -------------------------------------------------------- |
| 1     | Embedding Model               | ✅ Done     | Generates embeddings stored in ObjectBox                 |
| 2     | Vector Storage & Search       | ✅ Done     | Returns `List<ScoredEmbedding>` — input to resolver      |
| **3** | **Top-K Document Resolution** | **✅ Done** | **Outputs `List<RetrievedDocument>` for prompt builder** |
| 4     | Prompt Augmentation           | Planned     | Consumes `RetrievedDocument` to build LLM prompt         |
| 5     | LLM Generator                 | Planned     | Sends augmented prompt to Gemini                         |
| 6     | Chat UI                       | Planned     | Displays answer with source attribution                  |

---

_Document created: February 27, 2026_
_Relates to: [RAG_IMPLEMENTATION.md](RAG_IMPLEMENTATION.md) — Step 3_
