### PR TITLE
Fix two import parser regressions from recent PRs

### DIFF
--- a/lib/core/import/adapters/notion_adapter.dart
+++ b/lib/core/import/adapters/notion_adapter.dart
@@ -93,6 +93,12 @@ class NotionAdapter implements NoteImportAdapter {
       if (propMatch != null) {
         final rawKey = (propMatch.group(1) ?? '').trim();
         final key = rawKey.replaceAll(RegExp(r':\s*$'), '').trim().toLowerCase();
+        // Property lines always have a separator before a value. If a bold line
+        // has no colon separator after "**...**", treat it as normal body text.
+        final hasColonSeparator = RegExp(r'^\*\*[^*]+\*\*\s*:').hasMatch(line) || RegExp(r'^\*\*[^*]+:\*\*').hasMatch(line);
+        if (!hasColonSeparator) {
+          break;
+        }
         final value = (propMatch.groupCount >= 3 ? propMatch.group(3) : propMatch.group(2)) ?? '';
         propertyLines[key] = value.trim();
         bodyStart++;

--- a/lib/core/import/adapters/obsidian_adapter.dart
+++ b/lib/core/import/adapters/obsidian_adapter.dart
@@ -79,13 +79,11 @@ class ObsidianAdapter implements NoteImportAdapter {
     Map<String, dynamic> frontmatter = {};
     String body = text;
 
-    if (text.startsWith('---\n')) {
-      final end = text.indexOf('\n---\n', 4);
-      if (end != -1) {
-        final yamlBlock = text.substring(4, end);
-        frontmatter = _parseFrontmatter(yamlBlock);
-        body = text.substring(end + 5);
-      }
+    final frontmatterMatch = RegExp(r'^---\n([\s\S]*?)\n---(?:\n|$)').firstMatch(text);
+    if (frontmatterMatch != null) {
+      final yamlBlock = frontmatterMatch.group(1) ?? '';
+      frontmatter = _parseFrontmatter(yamlBlock);
+      body = text.substring(frontmatterMatch.end);
     }
 
     // ── Title resolution ───────────────────────────────────────────────────

--- a/test/core/import/adapters/notion_adapter_test.dart
+++ b/test/core/import/adapters/notion_adapter_test.dart
@@ -158,6 +158,15 @@ void main() {
       expect(notes.first.rawMetadata.containsKey('tags'), isTrue);
       expect(notes.first.rawMetadata.containsKey('created'), isTrue);
     });
+
+    test('keeps non-property bold intro lines in body', () async {
+      final input = [
+        {'path': 'note.md', 'content': '# Note\n**Important intro** keep this line.\n\nBody paragraph.'},
+      ];
+      final notes = await adapter.parse(input);
+      expect(notes.first.markdownContent, contains('**Important intro** keep this line.'));
+      expect(notes.first.rawMetadata.containsKey('important intro'), isFalse);
+    });
   });
 
   // ── CSV files skipped ──────────────────────────────────────────────────────

--- a/test/core/import/adapters/obsidian_adapter_test.dart
+++ b/test/core/import/adapters/obsidian_adapter_test.dart
@@ -157,6 +157,14 @@ void main() {
       expect(notes.first.rawMetadata['author'], 'Sambath');
     });
 
+    test('parses frontmatter when closing fence is at EOF', () async {
+      const md = '---\ntitle: EOF Title\n---';
+      final notes = await adapter.parse(md);
+      expect(notes, hasLength(1));
+      expect(notes.first.title, 'EOF Title');
+      expect(notes.first.markdownContent, isEmpty);
+    });
+
     test('note without frontmatter parses correctly', () async {
       const md = '# Plain Note\nJust text.';
       final notes = await adapter.parse(md);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this fixes

This PR applies two minimal, high-confidence fixes found while scanning recent PRs:

1. **Obsidian import frontmatter at EOF**
   - Bug: `---` frontmatter blocks were only detected when the closing fence was followed by a newline.
   - Impact: notes whose file ended immediately after closing `---` lost frontmatter metadata and fell back to filename title.
   - Fix: use a frontmatter regex that accepts closing fence at end-of-file.

2. **Notion import misclassifies body bold lines as properties**
   - Bug: top-of-file bold lines like `**Important intro** keep this line.` were parsed as metadata.
   - Impact: those lines were stripped from note body.
   - Fix: only treat lines as Notion property lines when they include an explicit colon separator format.

## Reproduction and verification

- Added targeted regression tests that failed before fixes and now pass:
  - `parses frontmatter when closing fence is at EOF` (Obsidian)
  - `keeps non-property bold intro lines in body` (Notion)
- Re-ran full adapter test suites after patches.

## Scope

Small parser-only changes + tests, no behavior changes outside import adapters.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc8de6b4-e7b9-44d0-b5e5-fede7920f401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc8de6b4-e7b9-44d0-b5e5-fede7920f401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

